### PR TITLE
Add basic example project

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,21 @@ function App() {
 }
 ```
 
+## Examples
+
+This repository includes demo projects under the `example` folder. The first
+one demonstrates basic usage by importing the components directly from the
+source code.
+
+```bash
+cd example/basic
+npm install
+npm run dev
+```
+
+Running the command above starts a Vite dev server so you can interact with the
+components without installing the package from npm.
+
 ## Development
 
 Install dependencies and run the test suite:

--- a/example/basic/index.html
+++ b/example/basic/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>React Chat UI Basic Example</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/example/basic/package.json
+++ b/example/basic/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "react-chat-ui-example-basic",
+  "private": true,
+  "scripts": {
+    "dev": "vite"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "vite": "^5.0.0"
+  }
+}

--- a/example/basic/src/main.jsx
+++ b/example/basic/src/main.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { ChatWindow } from '../../src';
+
+const messages = ['Hello', 'world!'];
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <ChatWindow messages={messages} />
+);


### PR DESCRIPTION
## Summary
- add a `basic` example project under `example`
- show how to run the example in the README

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684173367294832597fad7267dc3109e