### PR TITLE
Implement OpenAI message format and scoped styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # React Chat UI Library
 
 This library provides a lightweight and fully customizable chat user interface for React applications.
+Styles are built with Sass and include a prefixed subset of TailwindCSS utilities so they won't interfere with host applications.
 
 ## Installation
 
@@ -13,7 +14,24 @@ npm install react-chat-ui
 ```jsx
 import { ChatWindow } from 'react-chat-ui';
 
-const messages = ['Hello', 'World'];
+const messages = [
+  {
+    id: '1',
+    type: 'message',
+    role: 'assistant',
+    content: [
+      { type: 'text', text: 'Hello', annotations: [] }
+    ]
+  },
+  {
+    id: '2',
+    type: 'message',
+    role: 'user',
+    content: [
+      { type: 'text', text: 'World', annotations: [] }
+    ]
+  }
+];
 
 function App() {
   return <ChatWindow messages={messages} />;

--- a/__tests__/ChatWindow.test.js
+++ b/__tests__/ChatWindow.test.js
@@ -3,7 +3,25 @@ import { render, screen } from '@testing-library/react';
 import { ChatWindow } from '../src';
 
 test('renders messages', () => {
-  render(<ChatWindow messages={['hello', 'world']} />);
+  const messages = [
+    {
+      id: '1',
+      type: 'message',
+      role: 'user',
+      content: [
+        { type: 'text', text: 'hello', annotations: [] }
+      ]
+    },
+    {
+      id: '2',
+      type: 'message',
+      role: 'assistant',
+      content: [
+        { type: 'text', text: 'world', annotations: [] }
+      ]
+    }
+  ];
+  render(<ChatWindow messages={messages} />);
   expect(screen.getByText('hello')).toBeInTheDocument();
   expect(screen.getByText('world')).toBeInTheDocument();
 });

--- a/example/basic/src/main.jsx
+++ b/example/basic/src/main.jsx
@@ -2,7 +2,92 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { ChatWindow } from '../../../src';
 
-const messages = ['Hello', 'world!'];
+const messages = [
+  {
+    id: '1',
+    type: 'message',
+    role: 'user',
+    content: [
+      { type: 'text', text: 'Hi there!', annotations: [] }
+    ]
+  },
+  {
+    id: '2',
+    type: 'message',
+    role: 'assistant',
+    content: [
+      { type: 'text', text: 'Hello! How can I help you today?', annotations: [] }
+    ]
+  },
+  {
+    id: '3',
+    type: 'message',
+    role: 'user',
+    content: [
+      { type: 'text', text: 'Tell me a joke.', annotations: [] }
+    ]
+  },
+  {
+    id: '4',
+    type: 'message',
+    role: 'assistant',
+    content: [
+      {
+        type: 'text',
+        text: 'Why did the scarecrow win an award? Because he was outstanding in his field.',
+        annotations: []
+      }
+    ]
+  },
+  {
+    id: '5',
+    type: 'message',
+    role: 'user',
+    content: [
+      { type: 'text', text: "Haha, that's funny!", annotations: [] }
+    ]
+  },
+  {
+    id: '6',
+    type: 'message',
+    role: 'assistant',
+    content: [
+      { type: 'text', text: 'Glad you liked it. Need anything else?', annotations: [] }
+    ]
+  },
+  {
+    id: '7',
+    type: 'message',
+    role: 'user',
+    content: [
+      { type: 'text', text: 'No thanks, that was all.', annotations: [] }
+    ]
+  },
+  {
+    id: '8',
+    type: 'message',
+    role: 'assistant',
+    content: [
+      { type: 'text', text: 'You\'re welcome! Have a great day.', annotations: [] }
+    ]
+  },
+  {
+    id: '9',
+    type: 'message',
+    role: 'user',
+    content: [
+      { type: 'text', text: 'Bye!', annotations: [] }
+    ]
+  },
+  {
+    id: '10',
+    type: 'message',
+    role: 'assistant',
+    content: [
+      { type: 'text', text: 'Goodbye!', annotations: [] }
+    ]
+  }
+];
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <ChatWindow messages={messages} />

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,7 @@
 module.exports = {
   testEnvironment: 'jsdom',
   setupFilesAfterEnv: ['@testing-library/jest-dom'],
+  moduleNameMapper: {
+    '\\.(css|scss)$': 'identity-obj-proxy'
+  }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@testing-library/jest-dom": "^6.2.0",
         "@testing-library/react": "^14.1.2",
         "babel-jest": "^29.7.0",
+        "identity-obj-proxy": "^3.0.0",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^30.0.0-beta.3"
       },
@@ -4347,6 +4348,13 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/harmony-reflect": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/harmony-reflect/-/harmony-reflect-1.6.2.tgz",
+      "integrity": "sha512-HIp/n38R9kQjDEziXyDTuW3vvoxxyxjxFzXLrBr18uB47GnSt+G9D29fqrpM5ZkspMcPICud3XsBJQ4Y2URg8g==",
+      "dev": true,
+      "license": "(Apache-2.0 OR MPL-1.1)"
+    },
     "node_modules/has-bigints": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
@@ -4494,6 +4502,19 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/identity-obj-proxy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/identity-obj-proxy/-/identity-obj-proxy-3.0.0.tgz",
+      "integrity": "sha512-00n6YnVHKrinT9t0d9+5yZC6UBNJANpYEQvL2LlX6Ab9lnmxzIRcEmTPuyGScvl1+jKuCICX1Z0Ab1pPKKdikA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "harmony-reflect": "^1.4.6"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/import-local": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@testing-library/react": "^14.1.2",
     "babel-jest": "^29.7.0",
     "jest": "^29.7.0",
-    "jest-environment-jsdom": "^30.0.0-beta.3"
+    "jest-environment-jsdom": "^30.0.0-beta.3",
+    "identity-obj-proxy": "^3.0.0"
   }
 }

--- a/src/ChatMessage.jsx
+++ b/src/ChatMessage.jsx
@@ -1,5 +1,21 @@
 import React from 'react';
 
+// Render a single chat message. Supports either a plain string or an object in
+// the OpenAI response message format.
 export default function ChatMessage({ message }) {
-  return <div className="chat-message">{message}</div>;
+  if (message == null) return null;
+
+  const isObject = typeof message === 'object';
+  const role = isObject ? message.role : undefined;
+  const content = isObject ? message.content : [{ type: 'text', text: message }];
+
+  return (
+    <div
+      className={`rc-chat-message${role ? ` rc-role-${role}` : ''}`}
+    >
+      {content.map((part, idx) => (
+        part.type === 'text' ? <span key={idx}>{part.text}</span> : null
+      ))}
+    </div>
+  );
 }

--- a/src/ChatWindow.jsx
+++ b/src/ChatWindow.jsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import ChatMessage from './ChatMessage';
+import './styles.scss';
 
 export default function ChatWindow({ messages = [] }) {
   return (
-    <div className="chat-window">
+    <div className="rc-chat-window">
       {messages.map((msg, idx) => (
         <ChatMessage key={idx} message={msg} />
       ))}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,0 +1,28 @@
+/* Styles scoped with rc- prefix to avoid leaking */
+
+.rc-chat-window {
+  padding: 1rem;
+  background-color: #f3f4f6;
+  border-radius: 0.5rem;
+}
+.rc-chat-window > :not([hidden]) ~ :not([hidden]) {
+  margin-top: 0.5rem;
+}
+
+.rc-chat-message {
+  padding: 0.5rem;
+  border-radius: 0.375rem;
+}
+
+.rc-chat-message.rc-role-user {
+  background-color: #dbeafe;
+  color: #1e3a8a;
+  align-self: flex-end;
+}
+
+.rc-chat-message.rc-role-assistant {
+  background-color: #d1fae5;
+  color: #064e3b;
+  align-self: flex-start;
+}
+


### PR DESCRIPTION
## Summary
- scope styles via Sass with Tailwind-like utilities
- allow `ChatWindow` / `ChatMessage` to render OpenAI-style messages
- update example usage with a 5-turn conversation in the basic example
- configure Jest to stub style imports

## Testing
- `npm test -- -i`

------
https://chatgpt.com/codex/tasks/task_e_684179afaefc83259d39702596d1009a